### PR TITLE
Fix Flaresolverr missing ports

### DIFF
--- a/apps/flaresolverr/docker-compose.yml
+++ b/apps/flaresolverr/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     container_name: flaresolverr
     image: ghcr.io/flaresolverr/flaresolverr:v3.3.18
     restart: unless-stopped
+    ports:
+      - ${APP_PORT}:8191
     environment:
       - LOG_LEVEL=${FLARESOLVERR_LOG_LEVEL-info}
       - TZ=${TZ}


### PR DESCRIPTION
Prowlarr and other apps weren't connecting to Flaresolverr until the port setting was added to the docker-compose.yml 👍